### PR TITLE
Introduce os_pickup_audio-ar

### DIFF
--- a/os_pickup_audio-ar.mk
+++ b/os_pickup_audio-ar.mk
@@ -1,0 +1,3 @@
+ifeq ($(call my-dir),$(call project-path-for,qcom-audio))
+include $(call first-makefiles-under,$(call my-dir))
+endif


### PR DESCRIPTION
This is meant to land into hardware/qcom-caf/$(QCOM_HARDWARE_VARIANT)/audio for new platforms using AR variant of A-HAL such as taro and kalama, as these have dependencies on agm and arpal-lx.

The new folder structure now looks like this:

  hardware/qcom-caf/$(QCOM_HARDWARE_VARIANT)/audio
  ├─ agm (clo:platform/vendor/qcom/opensource/agm)
  ├─ pal (clo:platform/vendor/qcom/opensource/arpal-lx)
  └─ primary_hal (clo:platform/hardware/qcom/audio-ar)

Change-Id: Ieb7846a52e7d6a20f086f5ac02950df390b57556